### PR TITLE
Redesign interview mode with cinematic layout

### DIFF
--- a/client/components/PracticeSession.tsx
+++ b/client/components/PracticeSession.tsx
@@ -61,8 +61,10 @@ export default function PracticeSession({
   const [showHistory, setShowHistory] = useState(false);
 
   // Interview scene background images
-  const maleInterviewScene = "https://cdn.builder.io/api/v1/image/assets%2F9858961368ae4103b4a3c41674c30c55%2F82c53005c60f41e2a36ba6b7e288ade6?format=webp&width=800";
-  const femaleInterviewScene = "https://cdn.builder.io/api/v1/image/assets%2F9858961368ae4103b4a3c41674c30c55%2F5be9055b1cc54cd4bbf4b32d356bdeaf?format=webp&width=800";
+  const maleInterviewScene =
+    "https://cdn.builder.io/api/v1/image/assets%2F9858961368ae4103b4a3c41674c30c55%2F82c53005c60f41e2a36ba6b7e288ade6?format=webp&width=800";
+  const femaleInterviewScene =
+    "https://cdn.builder.io/api/v1/image/assets%2F9858961368ae4103b4a3c41674c30c55%2F5be9055b1cc54cd4bbf4b32d356bdeaf?format=webp&width=800";
 
   // Session tracking - temporarily disabled to fix React hooks issue
   // const {
@@ -415,14 +417,18 @@ export default function PracticeSession({
     <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 text-white relative overflow-hidden">
       {/* Cinematic overlay */}
       <div className="absolute inset-0 bg-gradient-to-t from-black/30 via-transparent to-black/30 pointer-events-none" />
-      
+
       {/* Header */}
       <div className="absolute top-0 left-0 right-0 z-50 bg-black/20 backdrop-blur-sm border-b border-white/10">
         <div className="max-w-7xl mx-auto px-6 py-4">
           <div className="flex items-center justify-between">
             <div className="flex items-center space-x-4">
               <Link to="/practice">
-                <Button variant="ghost" size="sm" className="gap-2 text-white/80 hover:text-white">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="gap-2 text-white/80 hover:text-white"
+                >
                   <ArrowLeft className="w-4 h-4" />
                   Back
                 </Button>
@@ -431,7 +437,10 @@ export default function PracticeSession({
                 <h1 className="text-lg font-semibold text-white">
                   {scenario} Practice
                 </h1>
-                <Badge variant="secondary" className="text-xs bg-white/10 text-white/70 border-white/20">
+                <Badge
+                  variant="secondary"
+                  className="text-xs bg-white/10 text-white/70 border-white/20"
+                >
                   Interview Mode
                 </Badge>
               </div>
@@ -444,7 +453,11 @@ export default function PracticeSession({
                 onClick={() => setSoundEnabled(!soundEnabled)}
                 className="text-white/80 hover:text-white"
               >
-                {soundEnabled ? <Volume2 className="w-4 h-4" /> : <VolumeX className="w-4 h-4" />}
+                {soundEnabled ? (
+                  <Volume2 className="w-4 h-4" />
+                ) : (
+                  <VolumeX className="w-4 h-4" />
+                )}
               </Button>
               <Button
                 variant="ghost"
@@ -456,12 +469,16 @@ export default function PracticeSession({
               </Button>
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                  <Button variant="ghost" size="sm" className="text-white/80 hover:text-white">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="text-white/80 hover:text-white"
+                  >
                     <MoreHorizontal className="w-4 h-4" />
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent className="bg-slate-800 border-slate-700">
-                  <DropdownMenuItem 
+                  <DropdownMenuItem
                     onClick={() => setShowHistory(true)}
                     className="text-white hover:bg-slate-700"
                   >
@@ -481,7 +498,7 @@ export default function PracticeSession({
         <div
           className="absolute inset-0 bg-cover bg-center bg-no-repeat"
           style={{
-            backgroundImage: `url(${userGender === "male" ? maleInterviewScene : femaleInterviewScene})`
+            backgroundImage: `url(${userGender === "male" ? maleInterviewScene : femaleInterviewScene})`,
           }}
         />
 
@@ -521,7 +538,9 @@ export default function PracticeSession({
                 </div>
               ) : (
                 <div>
-                  <p className="text-sm text-white/60">Ready to start the interview...</p>
+                  <p className="text-sm text-white/60">
+                    Ready to start the interview...
+                  </p>
                   <p className="text-xs text-white/40 mt-2">AI Interviewer</p>
                 </div>
               )}
@@ -540,8 +559,8 @@ export default function PracticeSession({
                 onClick={handleVoiceInput}
                 disabled={listening || isLoading}
                 className={`px-8 py-4 rounded-full transition-all duration-300 ${
-                  listening 
-                    ? "bg-red-500 hover:bg-red-600 animate-pulse" 
+                  listening
+                    ? "bg-red-500 hover:bg-red-600 animate-pulse"
                     : "bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700"
                 } text-white shadow-2xl`}
               >
@@ -600,10 +619,15 @@ export default function PracticeSession({
           </DialogHeader>
           <div className="space-y-4 max-h-96 overflow-y-auto pr-2">
             {conversation.length === 0 ? (
-              <p className="text-white/60 text-center py-8">No conversation history yet.</p>
+              <p className="text-white/60 text-center py-8">
+                No conversation history yet.
+              </p>
             ) : (
               conversation.map((item, index) => (
-                <div key={index} className="space-y-3 p-4 bg-slate-700/50 rounded-lg">
+                <div
+                  key={index}
+                  className="space-y-3 p-4 bg-slate-700/50 rounded-lg"
+                >
                   <div className="flex items-start space-x-3">
                     <div className="w-8 h-8 rounded-full bg-blue-500 flex items-center justify-center flex-shrink-0">
                       <span className="text-xs font-bold">U</span>

--- a/client/hooks/useSessionTracking.ts
+++ b/client/hooks/useSessionTracking.ts
@@ -1,5 +1,5 @@
-import { useEffect, useRef } from 'react';
-import { useUserAnalytics } from '@/contexts/UserAnalyticsContext';
+import { useEffect, useRef } from "react";
+import { useUserAnalytics } from "@/contexts/UserAnalyticsContext";
 
 export const useSessionTracking = (moduleName: string, autoStart = true) => {
   const {
@@ -8,7 +8,7 @@ export const useSessionTracking = (moduleName: string, autoStart = true) => {
     recordActivity,
     updateFluencyScore,
     addWordsLearned,
-    currentSession
+    currentSession,
   } = useUserAnalytics();
 
   const sessionStarted = useRef(false);
@@ -46,37 +46,37 @@ export const useSessionTracking = (moduleName: string, autoStart = true) => {
   // Activity tracking helpers
   const trackConversation = (duration: number, accuracy: number) => {
     recordActivity({
-      type: 'conversation',
+      type: "conversation",
       duration,
       accuracy,
-      timestamp: new Date()
+      timestamp: new Date(),
     });
   };
 
   const trackPractice = (duration: number, accuracy: number) => {
     recordActivity({
-      type: 'practice',
+      type: "practice",
       duration,
       accuracy,
-      timestamp: new Date()
+      timestamp: new Date(),
     });
   };
 
   const trackGrammar = (duration: number, accuracy: number) => {
     recordActivity({
-      type: 'grammar',
+      type: "grammar",
       duration,
       accuracy,
-      timestamp: new Date()
+      timestamp: new Date(),
     });
   };
 
   const trackPronunciation = (duration: number, accuracy: number) => {
     recordActivity({
-      type: 'pronunciation',
+      type: "pronunciation",
       duration,
       accuracy,
-      timestamp: new Date()
+      timestamp: new Date(),
     });
   };
 
@@ -99,6 +99,6 @@ export const useSessionTracking = (moduleName: string, autoStart = true) => {
     trackPronunciation,
     recordFluencyImprovement,
     recordVocabularyLearned,
-    currentSession
+    currentSession,
   };
 };


### PR DESCRIPTION
## Purpose

The user requested a complete redesign of the interview practice mode to create a more immersive, movie-like conversation experience. They wanted to remove the existing card-based layout and implement a cinematic interface with gender-specific background images, repositioned chat elements (AI responses in top-right, user messages on left), and a history feature accessible through a three-dots menu.

## Code changes

- **Complete UI overhaul**: Removed card-based layout and replaced with full-screen cinematic design using gradient backgrounds and backdrop blur effects
- **Gender-specific backgrounds**: Added male and female interview scene background images based on `userGender` prop
- **Repositioned chat interface**: Moved AI responses to top-right and user input to bottom with improved styling
- **Added history feature**: Implemented dropdown menu with three-dots icon and modal dialog to view conversation history
- **Enhanced visual design**: Applied movie-like styling with overlays, improved typography, and glassmorphism effects
- **Temporarily disabled session tracking**: Commented out `useSessionTracking` hook to resolve React hooks issues
- **Streamlined imports**: Removed unused components like `Card`, `CardContent`, and `AnimatedAvatar`
- **Improved responsive design**: Updated header and input controls for better mobile experience

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 6`

🔗 [Edit in Builder.io](https://builder.io/app/projects/9f82e80456f84f1f8fef3cb5f1a92dff/spark-landing)

👀 [Preview Link](https://9f82e80456f84f1f8fef3cb5f1a92dff-spark-landing.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>9f82e80456f84f1f8fef3cb5f1a92dff</projectId>-->
<!--<branchName>spark-landing</branchName>-->