### PR TITLE
Fix API routing and add function config for chat endpoint

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,17 @@
 {
+  "functions": {
+    "netlify/functions/api.ts": {
+      "maxDuration": 30
+    }
+  },
   "rewrites": [
-    { "source": "/(.*)", "destination": "/index.html" }
+    {
+      "source": "/api/(.*)",
+      "destination": "/netlify/functions/api"
+    },
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
   ]
 }


### PR DESCRIPTION
## Purpose
The user was experiencing a 405 Method Not Allowed error when trying to access the chat API endpoint. They wanted to integrate Azure OpenAI API with specific credentials and endpoint configuration for their chatbot functionality. The error indicated that the API routing was not properly configured to handle POST requests to the `/api/chat` endpoint.

## Code changes
- Added `functions` configuration in `vercel.json` to set a 30-second timeout for the API function
- Updated the `rewrites` section to properly route `/api/*` requests to `/netlify/functions/api`
- Maintained existing catch-all routing for static files to `/index.html`
- Fixed API endpoint routing to resolve the 405 Method Not Allowed errors

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 13`

🔗 [Edit in Builder.io](https://builder.io/app/projects/19df70804c0c4c5299256b600dd2e4f8/pulse-field)

👀 [Preview Link](https://19df70804c0c4c5299256b600dd2e4f8-pulse-field.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>19df70804c0c4c5299256b600dd2e4f8</projectId>-->
<!--<branchName>pulse-field</branchName>-->