### PR TITLE
Fix Netlify function redirect path for API routes

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,13 +3,12 @@
   functions = "netlify/functions"
   publish = "dist/spa"
 
-
 [functions]
   external_node_modules = ["express"]
   node_bundler = "esbuild"
-  
+
 [[redirects]]
   force = true
   from = "/api/*"
   status = 200
-  to = "/.netlify/functions/api/:splat"
+  to = "/.netlify/functions/api"


### PR DESCRIPTION
## Purpose

The user encountered an error where the pattern "netlify/functions/api.ts" defined in `functions` doesn't match any Serverless Functions inside the `api` directory. This indicates a mismatch between the configured function path and the actual function structure, requiring a fix to the redirect configuration.

## Code changes

- Updated the API redirect path in `netlify.toml` from `/.netlify/functions/api/:splat` to `/.netlify/functions/api`
- Removed the `:splat` parameter to match the actual function structure
- Minor formatting cleanup (removed extra blank lines and trailing whitespace)

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 14`

🔗 [Edit in Builder.io](https://builder.io/app/projects/19df70804c0c4c5299256b600dd2e4f8/mystic-realm)

👀 [Preview Link](https://19df70804c0c4c5299256b600dd2e4f8-mystic-realm.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>19df70804c0c4c5299256b600dd2e4f8</projectId>-->
<!--<branchName>mystic-realm</branchName>-->