### PR TITLE
Fix API routing configuration in vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,17 @@
 {
+  "functions": {
+    "netlify/functions/api.ts": {
+      "runtime": "@vercel/node"
+    }
+  },
   "rewrites": [
-    { "source": "/(.*)", "destination": "/index.html" }
+    {
+      "source": "/api/(.*)",
+      "destination": "/netlify/functions/api"
+    },
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
   ]
 }


### PR DESCRIPTION
## Purpose
The user was experiencing HTTP 405 errors when making API requests to `/api/chat` during interview practice sessions. The chat API was failing with "Method Not Allowed" errors, preventing the application from functioning properly.

## Code changes
- Added `functions` configuration to specify Node.js runtime for the API function
- Updated `rewrites` section to properly route `/api/*` requests to `/netlify/functions/api`
- Maintained existing catch-all routing for static files to `/index.html`

This configuration ensures API requests are properly routed to the serverless function instead of being treated as static file requests.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 16`

🔗 [Edit in Builder.io](https://builder.io/app/projects/19df70804c0c4c5299256b600dd2e4f8/curry-garden)

👀 [Preview Link](https://19df70804c0c4c5299256b600dd2e4f8-curry-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>19df70804c0c4c5299256b600dd2e4f8</projectId>-->
<!--<branchName>curry-garden</branchName>-->