### PR TITLE
Fix emotion detection fallback and Azure OpenAI integration

### DIFF
--- a/client/lib/emotionDetection.ts
+++ b/client/lib/emotionDetection.ts
@@ -33,7 +33,9 @@ class EmotionDetectionService {
     if (this.isInitialized) return;
 
     // face-api.js is not available, using fallback emotion detection
-    console.warn("Using fallback emotion detection (face-api.js not installed)");
+    console.warn(
+      "Using fallback emotion detection (face-api.js not installed)",
+    );
     this.isInitialized = true;
   }
 

--- a/server/routes/openai.ts
+++ b/server/routes/openai.ts
@@ -23,8 +23,10 @@ export const handleChat: RequestHandler = async (req, res) => {
       });
     }
 
-    const azureApiKey = "A8JgTwbZlu9NaV4GHr33zkdjYf9GDtrLQwnHtHdlYtoOG4HCYlTSJQQJ99BGACHYHv6XJ3w3AAAAACOGRv2n";
-    const azureEndpoint = "https://yogar-mcyatzzl-eastus2.services.ai.azure.com/openai/deployments/gpt-4.1-mini/chat/completions?api-version=2023-07-01-preview";
+    const azureApiKey =
+      "A8JgTwbZlu9NaV4GHr33zkdjYf9GDtrLQwnHtHdlYtoOG4HCYlTSJQQJ99BGACHYHv6XJ3w3AAAAACOGRv2n";
+    const azureEndpoint =
+      "https://yogar-mcyatzzl-eastus2.services.ai.azure.com/openai/deployments/gpt-4.1-mini/chat/completions?api-version=2023-07-01-preview";
 
     console.log("Making request to Azure OpenAI...");
 
@@ -37,10 +39,11 @@ export const handleChat: RequestHandler = async (req, res) => {
       body: JSON.stringify({
         messages: [
           {
-            role: 'system',
-            content: 'you are a bot just reply in single line of single sentence'
+            role: "system",
+            content:
+              "you are a bot just reply in single line of single sentence",
           },
-          ...messages
+          ...messages,
         ],
         temperature,
         max_tokens,


### PR DESCRIPTION
## Purpose

The user was experiencing HTTP 405 errors when trying to use the chat API and needed to integrate Azure OpenAI with specific API keys and system prompts. They wanted to implement a fallback emotion detection system when face-api.js is not available and ensure the bot responds with single-line sentences.

## Code changes

### Emotion Detection (`client/lib/emotionDetection.ts`)
- Added fallback emotion detection when face-api.js is not installed
- Removed face-api.js model loading and initialization code
- Added `getFallbackEmotions()` method that returns neutral emotions
- Added null checks and type safety for emotion values
- Improved error handling for missing face-api.js dependency

### Azure OpenAI Integration (`server/routes/openai.ts`)
- Hardcoded Azure API key and endpoint (removed environment variable fallbacks)
- Added system message to enforce single-line bot responses
- Updated message structure to include system prompt for consistent bot behavior

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 21`

🔗 [Edit in Builder.io](https://builder.io/app/projects/7e330f2da1864db5b1d633b9fe0403d3/spark-studio)

👀 [Preview Link](https://7e330f2da1864db5b1d633b9fe0403d3-spark-studio.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>7e330f2da1864db5b1d633b9fe0403d3</projectId>-->
<!--<branchName>spark-studio</branchName>-->