### PR TITLE
Add /api prefix to all server routes

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -18,14 +18,14 @@ export function createServer() {
   app.use(express.urlencoded({ extended: true }));
 
   // Example API routes
-  app.get("/ping", (_req, res) => {
+  app.get("/api/ping", (_req, res) => {
     res.json({ message: "Hello from Express server v2!" });
   });
 
-  app.get("/demo", handleDemo);
+  app.get("/api/demo", handleDemo);
 
   // AI Chat route
-  app.post("/chat", handleChat);
+  app.post("/api/chat", handleChat);
 
   return app;
 }


### PR DESCRIPTION
## Purpose
Fix 405 Method Not Allowed errors by standardizing API route paths. The user was experiencing HTTP 405 errors when the frontend tried to make POST requests to `/api/chat`, but the server routes were configured without the `/api` prefix, causing route mismatches.

## Code changes
- Updated all Express server routes to include `/api` prefix:
  - `/ping` → `/api/ping`
  - `/demo` → `/api/demo` 
  - `/chat` → `/api/chat`

This ensures the server routes match the frontend's expected API endpoints and resolves the HTTP 405 errors.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 30`

🔗 [Edit in Builder.io](https://builder.io/app/projects/2bb0b7f19ca04e4f9c6b4e70f7a91aa4/aura-hub)

👀 [Preview Link](https://2bb0b7f19ca04e4f9c6b4e70f7a91aa4-aura-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>2bb0b7f19ca04e4f9c6b4e70f7a91aa4</projectId>-->
<!--<branchName>aura-hub</branchName>-->