### PR TITLE
Remove /api prefix from Express middleware in Vite config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,8 +28,9 @@ function expressPlugin(): Plugin {
     configureServer(server) {
       const app = createServer();
 
-      // Add Express app as middleware to Vite dev server with /api prefix
-      server.middlewares.use("/api", app);
+      // Add Express app as middleware to Vite dev server
+      // The Express app already defines routes with /api prefix
+      server.middlewares.use(app);
     },
   };
 }


### PR DESCRIPTION
## Changes Made

Updated the Vite configuration to remove the `/api` prefix when mounting the Express app as middleware.

### Modified Files
- `vite.config.ts`

### Details
- Changed `server.middlewares.use("/api", app)` to `server.middlewares.use(app)`
- Updated comment to clarify that the Express app already defines routes with `/api` prefix
- This change delegates the route prefix handling to the Express app itself rather than adding it at the Vite middleware level

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 32`

🔗 [Edit in Builder.io](https://builder.io/app/projects/2bb0b7f19ca04e4f9c6b4e70f7a91aa4/pulse-verse)

👀 [Preview Link](https://2bb0b7f19ca04e4f9c6b4e70f7a91aa4-pulse-verse.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>2bb0b7f19ca04e4f9c6b4e70f7a91aa4</projectId>-->
<!--<branchName>pulse-verse</branchName>-->