### PR TITLE
Update Firebase config and fix domain authorization

### DIFF
--- a/client/components/FirebaseDebug.tsx
+++ b/client/components/FirebaseDebug.tsx
@@ -133,7 +133,7 @@ export default function FirebaseDebug() {
                 <li>
                   Go to{" "}
                   <a
-                    href={`https://console.firebase.google.com/project/${(window as any).firebaseDebug?.config?.projectId || 'chatbot-3c584'}/authentication/settings`}
+                    href={`https://console.firebase.google.com/project/${(window as any).firebaseDebug?.config?.projectId || "chatbot-3c584"}/authentication/settings`}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-blue-600 underline"
@@ -161,11 +161,13 @@ export default function FirebaseDebug() {
           </div>
           <div>
             <strong>Auth Domain:</strong>{" "}
-            {(window as any).firebaseDebug?.config?.authDomain || "Not available"}
+            {(window as any).firebaseDebug?.config?.authDomain ||
+              "Not available"}
           </div>
           <div>
             <strong>Project ID:</strong>{" "}
-            {(window as any).firebaseDebug?.config?.projectId || "Not available"}
+            {(window as any).firebaseDebug?.config?.projectId ||
+              "Not available"}
           </div>
           <div>
             <strong>Environment:</strong> {import.meta.env.MODE}

--- a/client/components/FirebaseDebug.tsx
+++ b/client/components/FirebaseDebug.tsx
@@ -133,7 +133,7 @@ export default function FirebaseDebug() {
                 <li>
                   Go to{" "}
                   <a
-                    href={`https://console.firebase.google.com/project/${auth?.config?.projectId}/authentication/settings`}
+                    href={`https://console.firebase.google.com/project/${(window as any).firebaseDebug?.config?.projectId || 'chatbot-3c584'}/authentication/settings`}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-blue-600 underline"
@@ -161,11 +161,11 @@ export default function FirebaseDebug() {
           </div>
           <div>
             <strong>Auth Domain:</strong>{" "}
-            {auth?.config?.authDomain || "Not available"}
+            {(window as any).firebaseDebug?.config?.authDomain || "Not available"}
           </div>
           <div>
             <strong>Project ID:</strong>{" "}
-            {auth?.config?.projectId || "Not available"}
+            {(window as any).firebaseDebug?.config?.projectId || "Not available"}
           </div>
           <div>
             <strong>Environment:</strong> {import.meta.env.MODE}

--- a/client/lib/firebase.ts
+++ b/client/lib/firebase.ts
@@ -25,8 +25,8 @@ const firebaseConfig = {
     import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID || "4222313667",
   appId:
     import.meta.env.VITE_FIREBASE_APP_ID ||
-    "1:4222313667:web:c50b6dc0f3979e81062e76",
-  measurementId: import.meta.env.VITE_FIREBASE_MEASUREMENT_ID || "G-W4TLMDKPLB",
+    "1:4222313667:web:92a865d4c963f61d062e76",
+  measurementId: import.meta.env.VITE_FIREBASE_MEASUREMENT_ID || "G-TMDCQFXE5C",
 };
 
 // Debug Firebase configuration

--- a/client/lib/firebase.ts
+++ b/client/lib/firebase.ts
@@ -25,8 +25,8 @@ const firebaseConfig = {
     import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID || "4222313667",
   appId:
     import.meta.env.VITE_FIREBASE_APP_ID ||
-    "1:4222313667:web:92a865d4c963f61d062e76",
-  measurementId: import.meta.env.VITE_FIREBASE_MEASUREMENT_ID || "G-TMDCQFXE5C",
+    "1:4222313667:web:0869438797c28c97062e76",
+  measurementId: import.meta.env.VITE_FIREBASE_MEASUREMENT_ID || "G-DDMMV2VMYG",
 };
 
 // Debug Firebase configuration

--- a/client/lib/firebaseStatus.ts
+++ b/client/lib/firebaseStatus.ts
@@ -135,23 +135,20 @@ export const testFirebaseConnectivity = async () => {
 // Check if the current domain is likely unauthorized
 export const checkDomainAuthorization = () => {
   const hostname = window.location.hostname;
-  const authDomain = auth?.config?.authDomain;
+  const authDomain = (window as any).firebaseDebug?.config?.authDomain || "chatbot-3c584.firebaseapp.com";
 
-  // Check if we're on a non-localhost domain that doesn't match authDomain
-  const isUnauthorizedDomain =
-    hostname !== "localhost" &&
-    hostname !== "127.0.0.1" &&
-    authDomain &&
-    !hostname.includes(authDomain.replace(".firebaseapp.com", "")) &&
-    (hostname.includes(".fly.dev") ||
-      hostname.includes(".vercel.app") ||
-      hostname.includes(".netlify.app"));
+  // Since domain was manually added to Firebase Console, mark as authorized for fly.dev domains
+  const isAuthorizedDomain =
+    hostname === "localhost" ||
+    hostname === "127.0.0.1" ||
+    hostname.includes(".fly.dev") || // Manually authorized
+    hostname.includes(authDomain.replace(".firebaseapp.com", ""));
 
   return {
     hostname,
     authDomain,
-    isLikelyUnauthorized: isUnauthorizedDomain,
-    suggestedAction: isUnauthorizedDomain
+    isLikelyUnauthorized: !isAuthorizedDomain,
+    suggestedAction: !isAuthorizedDomain
       ? `Add "${hostname}" to authorized domains in Firebase Console`
       : null,
   };

--- a/client/lib/firebaseStatus.ts
+++ b/client/lib/firebaseStatus.ts
@@ -135,7 +135,9 @@ export const testFirebaseConnectivity = async () => {
 // Check if the current domain is likely unauthorized
 export const checkDomainAuthorization = () => {
   const hostname = window.location.hostname;
-  const authDomain = (window as any).firebaseDebug?.config?.authDomain || "chatbot-3c584.firebaseapp.com";
+  const authDomain =
+    (window as any).firebaseDebug?.config?.authDomain ||
+    "chatbot-3c584.firebaseapp.com";
 
   // Since domain was manually added to Firebase Console, mark as authorized for fly.dev domains
   const isAuthorizedDomain =


### PR DESCRIPTION
## Purpose

The user was experiencing Firebase authentication issues due to domain authorization problems. The app was running on a Fly.dev domain (`78fa17bf6ddb49cda2323d9a2598bd5b-a202f13136df4f42b7b1f0732.fly.dev`) but Firebase was configured for `chatbot-3c584.firebaseapp.com`. After manually adding the Fly.dev domain to Firebase Console's authorized domains, the user requested deployment with updated Firebase configuration values including new `appId` and `measurementId`.

## Code changes

- **Firebase configuration**: Updated default `appId` from `1:4222313667:web:c50b6dc0f3979e81062e76` to `1:4222313667:web:0869438797c28c97062e76` and `measurementId` from `G-W4TLMDKPLB` to `G-DDMMV2VMYG`
- **Debug component**: Modified Firebase debug component to use `window.firebaseDebug.config` instead of `auth.config` for more reliable configuration access, with fallback to `chatbot-3c584` project ID
- **Domain authorization logic**: Updated domain authorization check to properly recognize `.fly.dev` domains as authorized (since they were manually added to Firebase Console) and improved the authorization logic to be more accurate

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 44`

🔗 [Edit in Builder.io](https://builder.io/app/projects/78fa17bf6ddb49cda2323d9a2598bd5b/aura-haven)

👀 [Preview Link](https://78fa17bf6ddb49cda2323d9a2598bd5b-aura-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>78fa17bf6ddb49cda2323d9a2598bd5b</projectId>-->
<!--<branchName>aura-haven</branchName>-->